### PR TITLE
docs: add Development Setup section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,38 @@ All data comes directly from FDIC Call Report filings, which insured institution
 
 ---
 
+## Development Setup
+
+### Prerequisites
+- Node.js (v18+)
+- npm
+
+### Install Dependencies
+```bash
+npm install
+```
+
+### Run the Dev Server
+```bash
+npm run dev
+```
+The app starts at [http://localhost:3005](http://localhost:3005).
+
+### Build for Production
+```bash
+npm run build
+```
+
+### Lint
+```bash
+npm run lint
+```
+
+### Deployment
+This project deploys to **Cloudflare Pages** via GitHub Actions.
+
+---
+
 ## 📊 Methodology
 
 ### 1. Data Source


### PR DESCRIPTION
## Summary
- Adds a "Development Setup" section to the README with install, dev server (port 3005), build, and lint instructions
- Documents Cloudflare Pages as the deploy target
- No existing content was removed or modified

Closes #1

## Test plan
- [x] Verified scripts match package.json
- [x] Dev port matches project registry (3005)
- [x] Deploy target matches registry (cloudflare-pages)
- [x] Existing README content preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)