### PR TITLE
docs: add Development Setup section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,44 @@ All data comes directly from FDIC Call Report filings, which insured institution
 
 ---
 
+## Development Setup
+
+### Prerequisites
+- Node.js (LTS recommended)
+- npm
+
+### Install dependencies
+
+```bash
+npm install
+```
+
+### Run the dev server
+
+```bash
+npm run dev
+```
+
+The app starts at [http://localhost:3005](http://localhost:3005).
+
+### Build for production
+
+```bash
+npm run build
+```
+
+### Lint
+
+```bash
+npm run lint
+```
+
+### Deploy target
+
+This project deploys to **Cloudflare Pages** via GitHub Actions.
+
+---
+
 ## 📊 Methodology
 
 ### 1. Data Source

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3005",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
## Summary
- Add a "Development Setup" section to the README with install, dev server, build, lint, and deploy target instructions
- Configure dev server to use port 3005 (assigned in project registry)
- Deploy target documented as Cloudflare Pages via GitHub Actions

Closes #1

## Test plan
- [x] Verified `npm run build` passes
- [ ] Verify `npm run dev` starts on port 3005
- [ ] Confirm README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)